### PR TITLE
Add Fastify JWT auth API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+DATABASE_URL=postgres://user:password@localhost:5432/dbname
+JWT_SECRET=your-secret-key
+PORT=3000

--- a/package.json
+++ b/package.json
@@ -6,19 +6,24 @@
   "scripts": {
     "build": "tsc",
     "start": "node dist/server.js",
-    "dev": "ts-node src/backend/src/server.ts",
+    "dev": "ts-node-dev src/backend/server.ts",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
     "express": "^4.19.2",
     "jsonwebtoken": "^9.0.2",
-    "pg": "^8.11.5"
+    "pg": "^8.11.5",
+    "fastify": "^4.25.1",
+    "bcrypt": "^5.1.1",
+    "dotenv": "^16.4.5"
   },
   "devDependencies": {
     "@types/express": "^5.0.3",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/pg": "^8.15.4",
     "ts-node": "^10.9.2",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "@types/bcrypt": "^5.0.2",
+    "ts-node-dev": "^2.0.0"
   }
 }

--- a/src/backend/controllers/auth.controller.ts
+++ b/src/backend/controllers/auth.controller.ts
@@ -1,0 +1,48 @@
+import { FastifyReply, FastifyRequest } from 'fastify';
+import bcrypt from 'bcrypt';
+import { signJwt } from '../utils/jwt';
+import { JwtPayload } from '../../shared/types';
+
+export const loginHandler = async (
+  request: FastifyRequest<{ Body: { email: string; password: string } }>,
+  reply: FastifyReply
+) => {
+  const { email, password } = request.body;
+  try {
+    const result = await request.server.pg.query<{
+      id: number;
+      email: string;
+      password_hash: string;
+      roles: string[];
+    }>('SELECT * FROM m_users WHERE email = $1', [email]);
+
+    if (result.rowCount === 0) {
+      return reply.code(401).send({ message: 'invalid credentials' });
+    }
+
+    const user = result.rows[0];
+    const match = await bcrypt.compare(password, user.password_hash);
+    if (!match) {
+      return reply.code(401).send({ message: 'invalid credentials' });
+    }
+
+    const payload: JwtPayload = {
+      id: user.id,
+      email: user.email,
+      roles: user.roles,
+    };
+
+    const token = signJwt(payload);
+    return reply.send({ token });
+  } catch (err) {
+    request.log.error(err);
+    return reply.code(500).send({ message: 'internal server error' });
+  }
+};
+
+export const meHandler = async (
+  request: FastifyRequest,
+  reply: FastifyReply
+) => {
+  return reply.send(request.user);
+};

--- a/src/backend/plugins/db.ts
+++ b/src/backend/plugins/db.ts
@@ -1,0 +1,23 @@
+import { FastifyPluginAsync } from 'fastify';
+import fp from 'fastify-plugin';
+import { Pool } from 'pg';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const dbPlugin: FastifyPluginAsync = async (fastify) => {
+  const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+  fastify.decorate('pg', pool);
+
+  fastify.addHook('onClose', async () => {
+    await pool.end();
+  });
+};
+
+export default fp(dbPlugin);
+
+declare module 'fastify' {
+  interface FastifyInstance {
+    pg: Pool;
+  }
+}

--- a/src/backend/routes/auth.routes.ts
+++ b/src/backend/routes/auth.routes.ts
@@ -1,0 +1,22 @@
+import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { loginHandler, meHandler } from '../controllers/auth.controller';
+import { verifyJwt } from '../utils/jwt';
+
+export default async function authRoutes(fastify: FastifyInstance) {
+  const authenticate = async (request: FastifyRequest, reply: FastifyReply) => {
+    const authHeader = request.headers.authorization;
+    if (!authHeader) {
+      return reply.code(401).send({ message: 'unauthorized' });
+    }
+    try {
+      const token = authHeader.replace('Bearer ', '');
+      const payload = verifyJwt(token);
+      request.user = payload;
+    } catch (err) {
+      return reply.code(401).send({ message: 'unauthorized' });
+    }
+  };
+
+  fastify.post('/auth/login', loginHandler);
+  fastify.get('/auth/me', { preHandler: authenticate }, meHandler);
+}

--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -1,0 +1,26 @@
+import Fastify from 'fastify';
+import dotenv from 'dotenv';
+import authRoutes from './routes/auth.routes';
+import dbPlugin from './plugins/db';
+
+dotenv.config();
+
+const server = Fastify();
+
+server.decorateRequest('user', null);
+
+server.register(dbPlugin);
+server.register(authRoutes);
+
+const start = async () => {
+  try {
+    const port = parseInt(process.env.PORT || '3000', 10);
+    await server.listen({ port, host: '0.0.0.0' });
+    console.log(`Server running on port ${port}`);
+  } catch (err) {
+    server.log.error(err);
+    process.exit(1);
+  }
+};
+
+start();

--- a/src/backend/utils/jwt.ts
+++ b/src/backend/utils/jwt.ts
@@ -1,0 +1,15 @@
+import jwt from 'jsonwebtoken';
+import dotenv from 'dotenv';
+import { JwtPayload } from '../../shared/types';
+
+dotenv.config();
+
+const JWT_SECRET = process.env.JWT_SECRET || 'secret';
+
+export const signJwt = (payload: JwtPayload) => {
+  return jwt.sign(payload, JWT_SECRET, { expiresIn: '1h' });
+};
+
+export const verifyJwt = (token: string): JwtPayload => {
+  return jwt.verify(token, JWT_SECRET) as JwtPayload;
+};

--- a/src/shared/types/index.d.ts
+++ b/src/shared/types/index.d.ts
@@ -1,0 +1,16 @@
+import { Pool } from 'pg';
+
+export interface JwtPayload {
+  id: number;
+  email: string;
+  roles: string[];
+}
+
+declare module 'fastify' {
+  interface FastifyRequest {
+    user?: JwtPayload;
+  }
+  interface FastifyInstance {
+    pg: Pool;
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,11 +2,11 @@
   "compilerOptions": {
     "target": "ES2019",
     "module": "commonjs",
-    "rootDir": "src/backend/src",
+    "rootDir": "src/backend",
     "outDir": "dist",
     "strict": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["src/backend/src/**/*"]
+  "include": ["src/backend/**/*"]
 }


### PR DESCRIPTION
## Summary
- implement JWT payload typings in `src/shared/types`
- add Fastify authentication controllers and routes
- provide Fastify PostgreSQL plugin and JWT utilities
- expose Fastify server entry point
- adjust TypeScript config and package scripts
- include example `.env` file

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6879c61b9d6883318c70943aa1cdf28d