### PR TITLE
Add Fastify offices CRUD API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@fastify/jwt": "^9.1.0",
         "bcrypt": "^5.1.1",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
@@ -67,6 +68,45 @@
         "fast-json-stringify": "^5.7.0"
       }
     },
+    "node_modules/@fastify/jwt": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/jwt/-/jwt-9.1.0.tgz",
+      "integrity": "sha512-CiGHCnS5cPMdb004c70sUWhQTfzrJHAeTywt7nVw6dAiI0z1o4WRvU94xfijhkaId4bIxTCOjFgn4sU+Gvk43w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/error": "^4.0.0",
+        "@lukeed/ms": "^2.0.2",
+        "fast-jwt": "^5.0.0",
+        "fastify-plugin": "^5.0.0",
+        "steed": "^1.1.3"
+      }
+    },
+    "node_modules/@fastify/jwt/node_modules/@fastify/error": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/error/-/error-4.2.0.tgz",
+      "integrity": "sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@fastify/merge-json-schemas": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@fastify/merge-json-schemas/-/merge-json-schemas-0.1.1.tgz",
@@ -102,6 +142,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@lukeed/ms": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@lukeed/ms/-/ms-2.0.2.tgz",
+      "integrity": "sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@mapbox/node-pre-gyp": {
@@ -504,6 +553,18 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
     },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
@@ -555,6 +616,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/bn.js": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
+      "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "1.20.3",
@@ -1012,6 +1079,21 @@
         }
       }
     },
+    "node_modules/fast-jwt": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/fast-jwt/-/fast-jwt-5.0.6.tgz",
+      "integrity": "sha512-LPE7OCGUl11q3ZgW681cEU2d0d2JZ37hhJAmetCgNyW8waVaJVZXhyFF6U2so1Iim58Yc7pfxJe2P7MNetQH2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@lukeed/ms": "^2.0.2",
+        "asn1.js": "^5.4.1",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "mnemonist": "^0.40.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/fast-querystring": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
@@ -1035,6 +1117,18 @@
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-2.4.0.tgz",
       "integrity": "sha512-ypuAmmMKInk5q7XcepxlnUWDLWv4GFtaJqAzWKqn62IpQ3pejtr5dTVbt3vwqVaMKmkNR55sTT+CqUKIaT21BA==",
       "license": "MIT"
+    },
+    "node_modules/fastfall": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/fastfall/-/fastfall-1.5.1.tgz",
+      "integrity": "sha512-KH6p+Z8AKPXnmA7+Iz2Lh8ARCMr+8WNPVludm1LGkZoD2MjY6LVnRMtTKhkdzI+jr0RzQWXKzKyBJm1zoHEL4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "reusify": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/fastify": {
       "version": "4.29.1",
@@ -1076,6 +1170,16 @@
       "integrity": "sha512-HCxs+YnRaWzCl+cWRYFnHmeRFyR5GVnJTAaCJQiYzQSDwK9MgJdyAsuL3nh0EWRCYMgQ5MeziymvmAhUHYHDUQ==",
       "license": "MIT"
     },
+    "node_modules/fastparallel": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/fastparallel/-/fastparallel-2.4.1.tgz",
+      "integrity": "sha512-qUmhxPgNHmvRjZKBFUNI0oZuuH9OlSIOXmJ98lhKPxMZZ7zS/Fi0wRHOihDSz0R1YiIOjxzOY4bq65YTcdBi2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4",
+        "xtend": "^4.0.2"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -1083,6 +1187,16 @@
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fastseries": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/fastseries/-/fastseries-1.7.2.tgz",
+      "integrity": "sha512-dTPFrPGS8SNSzAt7u/CbMKCJ3s01N04s4JFbORHcmyvVfVKmbhMD1VtRbh5enGHxkaQDqWyLefiKOGGmohGDDQ==",
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "node_modules/fill-range": {
@@ -1714,6 +1828,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -1780,6 +1900,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/mnemonist": {
+      "version": "0.40.3",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.40.3.tgz",
+      "integrity": "sha512-Vjyr90sJ23CKKH/qPAgUKicw/v6pRoamxIEDFOF8uSgFME7DqPRpHgRTejWVjkdGg5dXj0/NyxZHZ9bcjH+2uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "obliterator": "^2.0.4"
       }
     },
     "node_modules/ms": {
@@ -1881,6 +2010,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/obliterator": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-2.0.5.tgz",
+      "integrity": "sha512-42CPE9AhahZRsMNslczq0ctAEtqk8Eka26QofnqC346BZdHDySk3LWka23LI7ULIw11NmltpiLagIq8gBozxTw==",
+      "license": "MIT"
     },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",
@@ -2566,6 +2701,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/steed": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/steed/-/steed-1.1.3.tgz",
+      "integrity": "sha512-EUkci0FAUiE4IvGTSKcDJIQ/eRUP2JJb56+fvZ4sdnguLTqIdKjSxUe138poW8mkvKWXW2sFPrgTsxqoISnmoA==",
+      "license": "MIT",
+      "dependencies": {
+        "fastfall": "^1.5.0",
+        "fastparallel": "^2.2.0",
+        "fastq": "^1.3.0",
+        "fastseries": "^1.7.0",
+        "reusify": "^1.0.0"
       }
     },
     "node_modules/string_decoder": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
+    "@fastify/jwt": "^9.1.0",
     "bcrypt": "^5.1.1",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",

--- a/src/backend/controllers/offices.controller.ts
+++ b/src/backend/controllers/offices.controller.ts
@@ -1,0 +1,100 @@
+import { FastifyReply, FastifyRequest } from 'fastify';
+import {
+  createOfficeSchema,
+  updateOfficeSchema,
+} from '../schemas/offices.schema';
+import * as officeService from '../services/offices.service';
+
+export const getOfficesHandler = async (
+  _request: FastifyRequest,
+  reply: FastifyReply
+) => {
+  try {
+    const offices = await officeService.getOffices();
+    return reply.send({ data: offices });
+  } catch (err) {
+    reply.log.error(err);
+    return reply.code(500).send({ message: 'internal server error' });
+  }
+};
+
+export const getOfficeHandler = async (
+  request: FastifyRequest<{ Params: { id: string } }>,
+  reply: FastifyReply
+) => {
+  const id = Number(request.params.id);
+  if (Number.isNaN(id)) {
+    return reply.code(400).send({ message: 'invalid id' });
+  }
+  try {
+    const office = await officeService.getOfficeById(id);
+    if (!office) {
+      return reply.code(404).send({ message: 'not found' });
+    }
+    return reply.send({ data: office });
+  } catch (err) {
+    reply.log.error(err);
+    return reply.code(500).send({ message: 'internal server error' });
+  }
+};
+
+export const createOfficeHandler = async (
+  request: FastifyRequest,
+  reply: FastifyReply
+) => {
+  const parse = createOfficeSchema.safeParse(request.body);
+  if (!parse.success) {
+    return reply.code(400).send({ message: parse.error.message });
+  }
+  try {
+    const office = await officeService.createOffice(parse.data);
+    return reply.code(201).send({ data: office });
+  } catch (err) {
+    reply.log.error(err);
+    return reply.code(500).send({ message: 'internal server error' });
+  }
+};
+
+export const updateOfficeHandler = async (
+  request: FastifyRequest<{ Params: { id: string } }>,
+  reply: FastifyReply
+) => {
+  const id = Number(request.params.id);
+  if (Number.isNaN(id)) {
+    return reply.code(400).send({ message: 'invalid id' });
+  }
+  const parse = updateOfficeSchema.safeParse(request.body);
+  if (!parse.success) {
+    return reply.code(400).send({ message: parse.error.message });
+  }
+  try {
+    const office = await officeService.updateOffice(id, parse.data);
+    if (!office) {
+      return reply.code(404).send({ message: 'not found' });
+    }
+    return reply.send({ data: office });
+  } catch (err) {
+    reply.log.error(err);
+    return reply.code(500).send({ message: 'internal server error' });
+  }
+};
+
+export const deleteOfficeHandler = async (
+  request: FastifyRequest<{ Params: { id: string } }>,
+  reply: FastifyReply
+) => {
+  const id = Number(request.params.id);
+  if (Number.isNaN(id)) {
+    return reply.code(400).send({ message: 'invalid id' });
+  }
+  try {
+    const office = await officeService.deleteOffice(id);
+    if (!office) {
+      return reply.code(404).send({ message: 'not found' });
+    }
+    return reply.send({ data: office });
+  } catch (err) {
+    reply.log.error(err);
+    return reply.code(500).send({ message: 'internal server error' });
+  }
+};

--- a/src/backend/routes/offices.routes.ts
+++ b/src/backend/routes/offices.routes.ts
@@ -1,0 +1,16 @@
+import { FastifyInstance } from 'fastify';
+import {
+  getOfficesHandler,
+  getOfficeHandler,
+  createOfficeHandler,
+  updateOfficeHandler,
+  deleteOfficeHandler,
+} from '../controllers/offices.controller';
+
+export default async function officeRoutes(fastify: FastifyInstance) {
+  fastify.get('/offices', { onRequest: [fastify.authenticate] }, getOfficesHandler);
+  fastify.get<{ Params: { id: string } }>('/offices/:id', { onRequest: [fastify.authenticate] }, getOfficeHandler);
+  fastify.post('/offices', { onRequest: [fastify.authenticate] }, createOfficeHandler);
+  fastify.put<{ Params: { id: string } }>('/offices/:id', { onRequest: [fastify.authenticate] }, updateOfficeHandler);
+  fastify.delete<{ Params: { id: string } }>('/offices/:id', { onRequest: [fastify.authenticate] }, deleteOfficeHandler);
+}

--- a/src/backend/schemas/offices.schema.ts
+++ b/src/backend/schemas/offices.schema.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+
+export const createOfficeSchema = z.object({
+  name: z.string().min(1),
+  location: z.string().min(1),
+  is_active: z.boolean().optional(),
+});
+
+export const updateOfficeSchema = z.object({
+  name: z.string().min(1).optional(),
+  location: z.string().min(1).optional(),
+  is_active: z.boolean().optional(),
+});

--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -1,7 +1,9 @@
 import Fastify from 'fastify';
 import dotenv from 'dotenv';
 import authRoutes from './routes/auth.routes';
+import officeRoutes from './routes/offices.routes';
 import dbPlugin from './plugins/db';
+import jwtPlugin from './utils/jwt';
 
 dotenv.config();
 
@@ -10,7 +12,9 @@ const server = Fastify();
 server.decorateRequest('user', null);
 
 server.register(dbPlugin);
+server.register(jwtPlugin);
 server.register(authRoutes);
+server.register(officeRoutes);
 
 const start = async () => {
   try {

--- a/src/backend/services/offices.service.ts
+++ b/src/backend/services/offices.service.ts
@@ -1,0 +1,71 @@
+import pool from '../utils/db';
+import { Office } from '../../shared/types';
+
+export const getOffices = async (): Promise<Office[]> => {
+  const result = await pool.query<Office>(
+    'SELECT * FROM m_offices ORDER BY id'
+  );
+  return result.rows;
+};
+
+export const getOfficeById = async (id: number): Promise<Office | null> => {
+  const result = await pool.query<Office>(
+    'SELECT * FROM m_offices WHERE id = $1',
+    [id]
+  );
+  return result.rows[0] || null;
+};
+
+export const createOffice = async (
+  data: { name: string; location: string; is_active?: boolean }
+): Promise<Office> => {
+  const { name, location, is_active = true } = data;
+  const result = await pool.query<Office>(
+    'INSERT INTO m_offices (name, location, is_active, created_at, updated_at) VALUES ($1, $2, $3, now(), now()) RETURNING *',
+    [name, location, is_active]
+  );
+  return result.rows[0];
+};
+
+export const updateOffice = async (
+  id: number,
+  data: { name?: string; location?: string; is_active?: boolean }
+): Promise<Office | null> => {
+  const fields: string[] = [];
+  const values: any[] = [];
+  let idx = 1;
+
+  if (data.name !== undefined) {
+    fields.push(`name = $${idx++}`);
+    values.push(data.name);
+  }
+  if (data.location !== undefined) {
+    fields.push(`location = $${idx++}`);
+    values.push(data.location);
+  }
+  if (data.is_active !== undefined) {
+    fields.push(`is_active = $${idx++}`);
+    values.push(data.is_active);
+  }
+
+  if (fields.length === 0) {
+    return null;
+  }
+
+  fields.push('updated_at = now()');
+  values.push(id);
+
+  const result = await pool.query<Office>(
+    `UPDATE m_offices SET ${fields.join(', ')} WHERE id = $${idx} RETURNING *`,
+    values
+  );
+  return result.rows[0] || null;
+};
+
+export const deleteOffice = async (id: number): Promise<Office | null> => {
+  const result = await pool.query<Office>(
+    'UPDATE m_offices SET is_active = false, updated_at = now() WHERE id = $1 RETURNING *',
+    [id]
+  );
+  return result.rows[0] || null;
+};

--- a/src/backend/utils/jwt.ts
+++ b/src/backend/utils/jwt.ts
@@ -1,8 +1,30 @@
-import jwt from 'jsonwebtoken';
+import { FastifyPluginAsync, FastifyRequest, FastifyReply } from 'fastify';
+import fp from 'fastify-plugin';
+import fastifyJwt from '@fastify/jwt';
 import dotenv from 'dotenv';
+import jwt from 'jsonwebtoken';
 import { JwtPayload } from '../../shared/types';
 
 dotenv.config();
+
+const jwtPlugin: FastifyPluginAsync = async (fastify) => {
+  fastify.register(fastifyJwt, {
+    secret: process.env.JWT_SECRET || 'secret',
+  });
+
+  fastify.decorate(
+    'authenticate',
+    async (request: FastifyRequest, reply: FastifyReply) => {
+      try {
+        await request.jwtVerify();
+      } catch (err) {
+        reply.code(401).send({ message: 'unauthorized' });
+      }
+    }
+  );
+};
+
+export default fp(jwtPlugin);
 
 const JWT_SECRET = process.env.JWT_SECRET || 'secret';
 

--- a/src/shared/types/index.d.ts
+++ b/src/shared/types/index.d.ts
@@ -1,4 +1,5 @@
 import { Pool } from 'pg';
+import { FastifyRequest, FastifyReply } from 'fastify';
 
 export interface JwtPayload {
   id: number;
@@ -12,11 +13,25 @@ export interface User {
   roles: string[];
 }
 
+export interface Office {
+  id: number;
+  name: string;
+  location: string;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
 declare module 'fastify' {
-  interface FastifyRequest {
-    user?: JwtPayload;
-  }
   interface FastifyInstance {
     pg: Pool;
+    authenticate: (request: FastifyRequest, reply: FastifyReply) => Promise<void>;
+  }
+}
+
+declare module '@fastify/jwt' {
+  interface FastifyJWT {
+    payload: JwtPayload;
+    user: JwtPayload;
   }
 }


### PR DESCRIPTION
## Summary
- implement m_offices CRUD API using Fastify, Zod, PostgreSQL
- register JWT auth plugin and new routes
- define Office type and Fastify JWT typings
- install `@fastify/jwt`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6879deab9abc833182ae678ceba0f550