### PR TITLE
Implement Fastify users CRUD

### DIFF
--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -1,17 +1,1 @@
-import express from 'express';
-import dotenv from 'dotenv';
-import usersRouter from './routes/users.routes';
-
-dotenv.config();
-
-const app = express();
-app.use(express.json());
-
-app.use('/users', usersRouter);
-
-const port = process.env.PORT || 3000;
-app.listen(port, () => {
-  console.log(`Server running on port ${port}`);
-});
-
-export default app;
+export {};

--- a/src/backend/routes/users.routes.ts
+++ b/src/backend/routes/users.routes.ts
@@ -1,16 +1,16 @@
-import { Router } from 'express';
+import { FastifyInstance } from 'fastify';
 import {
-  getUsers,
-  createUser,
-  updateUser,
-  deleteUser,
+  getUsersHandler,
+  getUserHandler,
+  createUserHandler,
+  updateUserHandler,
+  deleteUserHandler,
 } from '../controllers/users.controller';
 
-const router = Router();
-
-router.get('/', getUsers);
-router.post('/', createUser);
-router.put('/:id', updateUser);
-router.delete('/:id', deleteUser);
-
-export default router;
+export default async function userRoutes(fastify: FastifyInstance) {
+  fastify.get('/users', { onRequest: [fastify.authenticate] }, getUsersHandler);
+  fastify.get<{ Params: { id: string } }>('/users/:id', { onRequest: [fastify.authenticate] }, getUserHandler);
+  fastify.post('/users', { onRequest: [fastify.authenticate] }, createUserHandler);
+  fastify.put<{ Params: { id: string } }>('/users/:id', { onRequest: [fastify.authenticate] }, updateUserHandler);
+  fastify.delete<{ Params: { id: string } }>('/users/:id', { onRequest: [fastify.authenticate] }, deleteUserHandler);
+}

--- a/src/backend/schemas/users.schema.ts
+++ b/src/backend/schemas/users.schema.ts
@@ -8,6 +8,5 @@ export const createUserSchema = z.object({
 
 export const updateUserSchema = z.object({
   email: z.string().email().optional(),
-  password: z.string().min(6).optional(),
   roles: z.array(z.string()).min(1).optional(),
 });

--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -2,6 +2,7 @@ import Fastify from 'fastify';
 import dotenv from 'dotenv';
 import authRoutes from './routes/auth.routes';
 import officeRoutes from './routes/offices.routes';
+import userRoutes from './routes/users.routes';
 import dbPlugin from './plugins/db';
 import jwtPlugin from './utils/jwt';
 
@@ -15,6 +16,7 @@ server.register(dbPlugin);
 server.register(jwtPlugin);
 server.register(authRoutes);
 server.register(officeRoutes);
+server.register(userRoutes);
 
 const start = async () => {
   try {

--- a/src/shared/types/index.d.ts
+++ b/src/shared/types/index.d.ts
@@ -11,6 +11,9 @@ export interface User {
   id: number;
   email: string;
   roles: string[];
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
 }
 
 export interface Office {


### PR DESCRIPTION
## Summary
- migrate user handlers to Fastify
- add Fastify routes for `/users`
- update user service to use logical delete and timestamps
- extend `User` type definitions
- register user routes in Fastify server

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6879e403ef6083318be2b45f957b816a