### PR TITLE
Implement positions CRUD API using Fastify

### DIFF
--- a/src/backend/controllers/positions.controller.ts
+++ b/src/backend/controllers/positions.controller.ts
@@ -1,0 +1,103 @@
+import { FastifyReply, FastifyRequest } from 'fastify';
+import {
+  createPosition,
+  deletePosition,
+  getPosition,
+  getPositions,
+  updatePosition,
+} from '../services/positions.service';
+import { createPositionSchema, updatePositionSchema } from '../schemas/positions.schema';
+
+export const getPositionsHandler = async (
+  request: FastifyRequest,
+  reply: FastifyReply
+) => {
+  try {
+    const positions = await getPositions();
+    return reply.send({ data: positions, message: 'success' });
+  } catch (err) {
+    request.log.error(err);
+    return reply.code(500).send({ message: 'internal server error' });
+  }
+};
+
+export const getPositionHandler = async (
+  request: FastifyRequest<{ Params: { id: string } }>,
+  reply: FastifyReply
+) => {
+  const id = Number(request.params.id);
+  if (Number.isNaN(id)) {
+    return reply.code(400).send({ message: 'invalid id' });
+  }
+  try {
+    const position = await getPosition(id);
+    if (!position) {
+      return reply.code(404).send({ message: 'not found' });
+    }
+    return reply.send({ data: position, message: 'success' });
+  } catch (err) {
+    request.log.error(err);
+    return reply.code(500).send({ message: 'internal server error' });
+  }
+};
+
+export const createPositionHandler = async (
+  request: FastifyRequest,
+  reply: FastifyReply
+) => {
+  const parse = createPositionSchema.safeParse(request.body);
+  if (!parse.success) {
+    return reply.code(400).send({ message: parse.error.message });
+  }
+  try {
+    const position = await createPosition(parse.data);
+    return reply.code(201).send({ data: position, message: 'success' });
+  } catch (err) {
+    request.log.error(err);
+    return reply.code(500).send({ message: 'internal server error' });
+  }
+};
+
+export const updatePositionHandler = async (
+  request: FastifyRequest<{ Params: { id: string } }>,
+  reply: FastifyReply
+) => {
+  const id = Number(request.params.id);
+  if (Number.isNaN(id)) {
+    return reply.code(400).send({ message: 'invalid id' });
+  }
+  const parse = updatePositionSchema.safeParse(request.body);
+  if (!parse.success) {
+    return reply.code(400).send({ message: parse.error.message });
+  }
+  try {
+    const position = await updatePosition(id, parse.data);
+    if (!position) {
+      return reply.code(404).send({ message: 'not found' });
+    }
+    return reply.send({ data: position, message: 'success' });
+  } catch (err) {
+    request.log.error(err);
+    return reply.code(500).send({ message: 'internal server error' });
+  }
+};
+
+export const deletePositionHandler = async (
+  request: FastifyRequest<{ Params: { id: string } }>,
+  reply: FastifyReply
+) => {
+  const id = Number(request.params.id);
+  if (Number.isNaN(id)) {
+    return reply.code(400).send({ message: 'invalid id' });
+  }
+  try {
+    const position = await deletePosition(id);
+    if (!position) {
+      return reply.code(404).send({ message: 'not found' });
+    }
+    return reply.send({ data: position, message: 'success' });
+  } catch (err) {
+    request.log.error(err);
+    return reply.code(500).send({ message: 'internal server error' });
+  }
+};

--- a/src/backend/routes/positions.routes.ts
+++ b/src/backend/routes/positions.routes.ts
@@ -1,0 +1,16 @@
+import { FastifyInstance } from 'fastify';
+import {
+  createPositionHandler,
+  deletePositionHandler,
+  getPositionHandler,
+  getPositionsHandler,
+  updatePositionHandler,
+} from '../controllers/positions.controller';
+
+export default async function positionsRoutes(fastify: FastifyInstance) {
+  fastify.get('/positions', getPositionsHandler);
+  fastify.get('/positions/:id', getPositionHandler);
+  fastify.post('/positions', createPositionHandler);
+  fastify.put('/positions/:id', updatePositionHandler);
+  fastify.delete('/positions/:id', deletePositionHandler);
+}

--- a/src/backend/schemas/positions.schema.ts
+++ b/src/backend/schemas/positions.schema.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+
+export const createPositionSchema = z.object({
+  name: z.string().min(1),
+  description: z.string().optional(),
+  is_active: z.boolean().optional().default(true),
+});
+
+export const updatePositionSchema = z.object({
+  name: z.string().min(1).optional(),
+  description: z.string().optional(),
+  is_active: z.boolean().optional(),
+});

--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -1,6 +1,7 @@
 import Fastify from 'fastify';
 import dotenv from 'dotenv';
 import authRoutes from './routes/auth.routes';
+import positionsRoutes from './routes/positions.routes';
 import dbPlugin from './plugins/db';
 
 dotenv.config();
@@ -11,6 +12,7 @@ server.decorateRequest('user', null);
 
 server.register(dbPlugin);
 server.register(authRoutes);
+server.register(positionsRoutes);
 
 const start = async () => {
   try {

--- a/src/backend/services/positions.service.ts
+++ b/src/backend/services/positions.service.ts
@@ -1,0 +1,71 @@
+import pool from '../utils/db';
+import { Position } from '../../shared/types';
+
+export const getPositions = async (): Promise<Position[]> => {
+  const result = await pool.query<Position>(
+    'SELECT * FROM m_positions WHERE is_active = true ORDER BY id'
+  );
+  return result.rows;
+};
+
+export const getPosition = async (id: number): Promise<Position | null> => {
+  const result = await pool.query<Position>(
+    'SELECT * FROM m_positions WHERE id = $1 AND is_active = true',
+    [id]
+  );
+  return result.rows[0] || null;
+};
+
+export const createPosition = async (data: {
+  name: string;
+  description?: string;
+  is_active?: boolean;
+}): Promise<Position> => {
+  const result = await pool.query<Position>(
+    'INSERT INTO m_positions (name, description, is_active, created_at, updated_at) VALUES ($1, $2, $3, now(), now()) RETURNING *',
+    [data.name, data.description ?? null, data.is_active ?? true]
+  );
+  return result.rows[0];
+};
+
+export const updatePosition = async (
+  id: number,
+  data: { name?: string; description?: string; is_active?: boolean }
+): Promise<Position | null> => {
+  const fields: string[] = [];
+  const values: any[] = [];
+  let idx = 1;
+
+  if (data.name !== undefined) {
+    fields.push(`name = $${idx++}`);
+    values.push(data.name);
+  }
+  if (data.description !== undefined) {
+    fields.push(`description = $${idx++}`);
+    values.push(data.description);
+  }
+  if (data.is_active !== undefined) {
+    fields.push(`is_active = $${idx++}`);
+    values.push(data.is_active);
+  }
+
+  if (fields.length === 0) {
+    return null;
+  }
+
+  fields.push(`updated_at = now()`);
+  values.push(id);
+  const result = await pool.query<Position>(
+    `UPDATE m_positions SET ${fields.join(', ')} WHERE id = $${idx} RETURNING *`,
+    values
+  );
+  return result.rows[0] || null;
+};
+
+export const deletePosition = async (id: number): Promise<Position | null> => {
+  const result = await pool.query<Position>(
+    'UPDATE m_positions SET is_active = false, updated_at = now() WHERE id = $1 RETURNING *',
+    [id]
+  );
+  return result.rows[0] || null;
+};

--- a/src/shared/types/index.d.ts
+++ b/src/shared/types/index.d.ts
@@ -12,6 +12,15 @@ export interface User {
   roles: string[];
 }
 
+export interface Position {
+  id: number;
+  name: string;
+  description: string | null;
+  is_active: boolean;
+  created_at: Date;
+  updated_at: Date;
+}
+
 declare module 'fastify' {
   interface FastifyRequest {
     user?: JwtPayload;


### PR DESCRIPTION
## Summary
- add m_positions schema validation with zod
- implement service layer for m_positions table
- add Fastify controllers for positions
- wire positions routes into Fastify server
- define `Position` interface in shared types

## Testing
- `npm run build` *(fails: Cannot find module types)*

------
https://chatgpt.com/codex/tasks/task_e_6879da1c628483318e9d380565a4b4e3