### PR TITLE
Fix office CRUD filtering

### DIFF
--- a/src/backend/controllers/offices.controller.ts
+++ b/src/backend/controllers/offices.controller.ts
@@ -39,7 +39,7 @@ export const getOfficeHandler = async (
 };
 
 export const createOfficeHandler = async (
-  request: FastifyRequest,
+  request: FastifyRequest<{ Body: { name: string; location: string } }>,
   reply: FastifyReply
 ) => {
   const parse = createOfficeSchema.safeParse(request.body);
@@ -56,7 +56,7 @@ export const createOfficeHandler = async (
 };
 
 export const updateOfficeHandler = async (
-  request: FastifyRequest<{ Params: { id: string } }>,
+  request: FastifyRequest<{ Params: { id: string }; Body: { name?: string; location?: string } }>,
   reply: FastifyReply
 ) => {
   const id = Number(request.params.id);

--- a/src/backend/schemas/offices.schema.ts
+++ b/src/backend/schemas/offices.schema.ts
@@ -3,11 +3,9 @@ import { z } from 'zod';
 export const createOfficeSchema = z.object({
   name: z.string().min(1),
   location: z.string().min(1),
-  is_active: z.boolean().optional(),
 });
 
 export const updateOfficeSchema = z.object({
   name: z.string().min(1).optional(),
   location: z.string().min(1).optional(),
-  is_active: z.boolean().optional(),
 });

--- a/src/backend/services/offices.service.ts
+++ b/src/backend/services/offices.service.ts
@@ -1,35 +1,35 @@
 import pool from '../utils/db';
-import { Office } from '../../shared/types';
+import { Office } from '../../shared/types/offices';
 
 export const getOffices = async (): Promise<Office[]> => {
   const result = await pool.query<Office>(
-    'SELECT * FROM m_offices ORDER BY id'
+    'SELECT * FROM m_offices WHERE is_active = true ORDER BY id'
   );
   return result.rows;
 };
 
 export const getOfficeById = async (id: number): Promise<Office | null> => {
   const result = await pool.query<Office>(
-    'SELECT * FROM m_offices WHERE id = $1',
+    'SELECT * FROM m_offices WHERE id = $1 AND is_active = true',
     [id]
   );
   return result.rows[0] || null;
 };
 
 export const createOffice = async (
-  data: { name: string; location: string; is_active?: boolean }
+  data: { name: string; location: string }
 ): Promise<Office> => {
-  const { name, location, is_active = true } = data;
+  const { name, location } = data;
   const result = await pool.query<Office>(
-    'INSERT INTO m_offices (name, location, is_active, created_at, updated_at) VALUES ($1, $2, $3, now(), now()) RETURNING *',
-    [name, location, is_active]
+    'INSERT INTO m_offices (name, location, is_active, created_at, updated_at) VALUES ($1, $2, true, now(), now()) RETURNING *',
+    [name, location]
   );
   return result.rows[0];
 };
 
 export const updateOffice = async (
   id: number,
-  data: { name?: string; location?: string; is_active?: boolean }
+  data: { name?: string; location?: string }
 ): Promise<Office | null> => {
   const fields: string[] = [];
   const values: any[] = [];
@@ -43,11 +43,6 @@ export const updateOffice = async (
     fields.push(`location = $${idx++}`);
     values.push(data.location);
   }
-  if (data.is_active !== undefined) {
-    fields.push(`is_active = $${idx++}`);
-    values.push(data.is_active);
-  }
-
   if (fields.length === 0) {
     return null;
   }
@@ -56,7 +51,7 @@ export const updateOffice = async (
   values.push(id);
 
   const result = await pool.query<Office>(
-    `UPDATE m_offices SET ${fields.join(', ')} WHERE id = $${idx} RETURNING *`,
+    `UPDATE m_offices SET ${fields.join(', ')} WHERE id = $${idx} AND is_active = true RETURNING *`,
     values
   );
   return result.rows[0] || null;
@@ -64,7 +59,7 @@ export const updateOffice = async (
 
 export const deleteOffice = async (id: number): Promise<Office | null> => {
   const result = await pool.query<Office>(
-    'UPDATE m_offices SET is_active = false, updated_at = now() WHERE id = $1 RETURNING *',
+    'UPDATE m_offices SET is_active = false, updated_at = now() WHERE id = $1 AND is_active = true RETURNING *',
     [id]
   );
   return result.rows[0] || null;

--- a/src/shared/types/offices.ts
+++ b/src/shared/types/offices.ts
@@ -1,0 +1,8 @@
+export interface Office {
+  id: number;
+  name: string;
+  location: string;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}


### PR DESCRIPTION
## Summary
- enforce `is_active` filtering for office queries
- restrict office schemas to name and location
- add Office type export

## Testing
- `npm run build` *(fails: cannot find module types)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6879e443c5c08331ba4de77c8a737e43