### PR TITLE
Add employees CRUD API

### DIFF
--- a/src/backend/controllers/employees.controller.ts
+++ b/src/backend/controllers/employees.controller.ts
@@ -1,0 +1,100 @@
+import { FastifyReply, FastifyRequest } from 'fastify';
+import {
+  createEmployeeSchema,
+  updateEmployeeSchema,
+} from '../schemas/employees.schema';
+import * as employeeService from '../services/employees.service';
+
+export const getEmployeesHandler = async (
+  _request: FastifyRequest,
+  reply: FastifyReply
+) => {
+  try {
+    const employees = await employeeService.getEmployees();
+    return reply.send({ data: employees });
+  } catch (err) {
+    reply.log.error(err);
+    return reply.code(500).send({ message: 'internal server error' });
+  }
+};
+
+export const getEmployeeHandler = async (
+  request: FastifyRequest<{ Params: { id: string } }>,
+  reply: FastifyReply
+) => {
+  const id = Number(request.params.id);
+  if (Number.isNaN(id)) {
+    return reply.code(400).send({ message: 'invalid id' });
+  }
+  try {
+    const employee = await employeeService.getEmployeeById(id);
+    if (!employee) {
+      return reply.code(404).send({ message: 'not found' });
+    }
+    return reply.send({ data: employee });
+  } catch (err) {
+    reply.log.error(err);
+    return reply.code(500).send({ message: 'internal server error' });
+  }
+};
+
+export const createEmployeeHandler = async (
+  request: FastifyRequest,
+  reply: FastifyReply
+) => {
+  const parse = createEmployeeSchema.safeParse(request.body);
+  if (!parse.success) {
+    return reply.code(400).send({ message: parse.error.message });
+  }
+  try {
+    const employee = await employeeService.createEmployee(parse.data);
+    return reply.code(201).send({ data: employee });
+  } catch (err) {
+    reply.log.error(err);
+    return reply.code(500).send({ message: 'internal server error' });
+  }
+};
+
+export const updateEmployeeHandler = async (
+  request: FastifyRequest<{ Params: { id: string } }>,
+  reply: FastifyReply
+) => {
+  const id = Number(request.params.id);
+  if (Number.isNaN(id)) {
+    return reply.code(400).send({ message: 'invalid id' });
+  }
+  const parse = updateEmployeeSchema.safeParse(request.body);
+  if (!parse.success) {
+    return reply.code(400).send({ message: parse.error.message });
+  }
+  try {
+    const employee = await employeeService.updateEmployee(id, parse.data);
+    if (!employee) {
+      return reply.code(404).send({ message: 'not found' });
+    }
+    return reply.send({ data: employee });
+  } catch (err) {
+    reply.log.error(err);
+    return reply.code(500).send({ message: 'internal server error' });
+  }
+};
+
+export const deleteEmployeeHandler = async (
+  request: FastifyRequest<{ Params: { id: string } }>,
+  reply: FastifyReply
+) => {
+  const id = Number(request.params.id);
+  if (Number.isNaN(id)) {
+    return reply.code(400).send({ message: 'invalid id' });
+  }
+  try {
+    const employee = await employeeService.deleteEmployee(id);
+    if (!employee) {
+      return reply.code(404).send({ message: 'not found' });
+    }
+    return reply.send({ data: employee });
+  } catch (err) {
+    reply.log.error(err);
+    return reply.code(500).send({ message: 'internal server error' });
+  }
+};

--- a/src/backend/routes/employees.routes.ts
+++ b/src/backend/routes/employees.routes.ts
@@ -1,0 +1,16 @@
+import { FastifyInstance } from 'fastify';
+import {
+  getEmployeesHandler,
+  getEmployeeHandler,
+  createEmployeeHandler,
+  updateEmployeeHandler,
+  deleteEmployeeHandler,
+} from '../controllers/employees.controller';
+
+export default async function employeeRoutes(fastify: FastifyInstance) {
+  fastify.get('/employees', { onRequest: [fastify.authenticate] }, getEmployeesHandler);
+  fastify.get<{ Params: { id: string } }>('/employees/:id', { onRequest: [fastify.authenticate] }, getEmployeeHandler);
+  fastify.post('/employees', { onRequest: [fastify.authenticate] }, createEmployeeHandler);
+  fastify.put<{ Params: { id: string } }>('/employees/:id', { onRequest: [fastify.authenticate] }, updateEmployeeHandler);
+  fastify.delete<{ Params: { id: string } }>('/employees/:id', { onRequest: [fastify.authenticate] }, deleteEmployeeHandler);
+}

--- a/src/backend/schemas/employees.schema.ts
+++ b/src/backend/schemas/employees.schema.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+
+export const createEmployeeSchema = z.object({
+  employee_code: z.string().min(1),
+  full_name: z.string().min(1),
+  email: z.string().email(),
+  hire_date: z.string().min(1),
+  is_active: z.boolean().optional(),
+});
+
+export const updateEmployeeSchema = z.object({
+  employee_code: z.string().min(1).optional(),
+  full_name: z.string().min(1).optional(),
+  email: z.string().email().optional(),
+  hire_date: z.string().min(1).optional(),
+  is_active: z.boolean().optional(),
+});

--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -4,6 +4,7 @@ import authRoutes from './routes/auth.routes';
 import officeRoutes from './routes/offices.routes';
 import dbPlugin from './plugins/db';
 import jwtPlugin from './utils/jwt';
+import employeeRoutes from './routes/employees.routes';
 
 dotenv.config();
 
@@ -15,6 +16,7 @@ server.register(dbPlugin);
 server.register(jwtPlugin);
 server.register(authRoutes);
 server.register(officeRoutes);
+server.register(employeeRoutes);
 
 const start = async () => {
   try {

--- a/src/backend/services/employees.service.ts
+++ b/src/backend/services/employees.service.ts
@@ -1,0 +1,91 @@
+import pool from '../utils/db';
+import { Employee } from '../../shared/types';
+
+export const getEmployees = async (): Promise<Employee[]> => {
+  const result = await pool.query<Employee>(
+    'SELECT * FROM m_employees ORDER BY id'
+  );
+  return result.rows;
+};
+
+export const getEmployeeById = async (id: number): Promise<Employee | null> => {
+  const result = await pool.query<Employee>(
+    'SELECT * FROM m_employees WHERE id = $1',
+    [id]
+  );
+  return result.rows[0] || null;
+};
+
+export const createEmployee = async (
+  data: {
+    employee_code: string;
+    full_name: string;
+    email: string;
+    hire_date: string;
+    is_active?: boolean;
+  }
+): Promise<Employee> => {
+  const { employee_code, full_name, email, hire_date, is_active = true } = data;
+  const result = await pool.query<Employee>(
+    'INSERT INTO m_employees (employee_code, full_name, email, hire_date, is_active, created_at, updated_at) VALUES ($1, $2, $3, $4, $5, now(), now()) RETURNING *',
+    [employee_code, full_name, email, hire_date, is_active]
+  );
+  return result.rows[0];
+};
+
+export const updateEmployee = async (
+  id: number,
+  data: {
+    employee_code?: string;
+    full_name?: string;
+    email?: string;
+    hire_date?: string;
+    is_active?: boolean;
+  }
+): Promise<Employee | null> => {
+  const fields: string[] = [];
+  const values: any[] = [];
+  let idx = 1;
+
+  if (data.employee_code !== undefined) {
+    fields.push(`employee_code = $${idx++}`);
+    values.push(data.employee_code);
+  }
+  if (data.full_name !== undefined) {
+    fields.push(`full_name = $${idx++}`);
+    values.push(data.full_name);
+  }
+  if (data.email !== undefined) {
+    fields.push(`email = $${idx++}`);
+    values.push(data.email);
+  }
+  if (data.hire_date !== undefined) {
+    fields.push(`hire_date = $${idx++}`);
+    values.push(data.hire_date);
+  }
+  if (data.is_active !== undefined) {
+    fields.push(`is_active = $${idx++}`);
+    values.push(data.is_active);
+  }
+
+  if (fields.length === 0) {
+    return null;
+  }
+
+  fields.push('updated_at = now()');
+  values.push(id);
+
+  const result = await pool.query<Employee>(
+    `UPDATE m_employees SET ${fields.join(', ')} WHERE id = $${idx} RETURNING *`,
+    values
+  );
+  return result.rows[0] || null;
+};
+
+export const deleteEmployee = async (id: number): Promise<Employee | null> => {
+  const result = await pool.query<Employee>(
+    'UPDATE m_employees SET is_active = false, updated_at = now() WHERE id = $1 RETURNING *',
+    [id]
+  );
+  return result.rows[0] || null;
+};

--- a/src/shared/types/index.d.ts
+++ b/src/shared/types/index.d.ts
@@ -22,6 +22,17 @@ export interface Office {
   updated_at: string;
 }
 
+export interface Employee {
+  id: number;
+  employee_code: string;
+  full_name: string;
+  email: string;
+  hire_date: string;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
 declare module 'fastify' {
   interface FastifyInstance {
     pg: Pool;


### PR DESCRIPTION
## Summary
- add Employee type
- add employees schema, service, controller and routes
- register employees routes in the Fastify server

## Testing
- `npm run build` *(fails: cannot find module 'fastify', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6879e62a48808331b311769ad2f382aa