### PR TITLE
Implement departments API

### DIFF
--- a/src/backend/controllers/departments.controller.ts
+++ b/src/backend/controllers/departments.controller.ts
@@ -1,0 +1,100 @@
+import { FastifyReply, FastifyRequest } from 'fastify';
+import {
+  createDepartmentSchema,
+  updateDepartmentSchema,
+} from '../schemas/departments.schema';
+import * as departmentService from '../services/departments.service';
+
+export const getDepartmentsHandler = async (
+  _request: FastifyRequest,
+  reply: FastifyReply
+) => {
+  try {
+    const departments = await departmentService.getDepartments();
+    return reply.send({ data: departments });
+  } catch (err) {
+    reply.log.error(err);
+    return reply.code(500).send({ message: 'internal server error' });
+  }
+};
+
+export const getDepartmentHandler = async (
+  request: FastifyRequest<{ Params: { id: string } }>,
+  reply: FastifyReply
+) => {
+  const id = Number(request.params.id);
+  if (Number.isNaN(id)) {
+    return reply.code(400).send({ message: 'invalid id' });
+  }
+  try {
+    const department = await departmentService.getDepartmentById(id);
+    if (!department) {
+      return reply.code(404).send({ message: 'not found' });
+    }
+    return reply.send({ data: department });
+  } catch (err) {
+    reply.log.error(err);
+    return reply.code(500).send({ message: 'internal server error' });
+  }
+};
+
+export const createDepartmentHandler = async (
+  request: FastifyRequest<{ Body: { department_code: string; name: string; office_id: number } }>,
+  reply: FastifyReply
+) => {
+  const parse = createDepartmentSchema.safeParse(request.body);
+  if (!parse.success) {
+    return reply.code(400).send({ message: parse.error.message });
+  }
+  try {
+    const department = await departmentService.createDepartment(parse.data);
+    return reply.code(201).send({ data: department });
+  } catch (err) {
+    reply.log.error(err);
+    return reply.code(500).send({ message: 'internal server error' });
+  }
+};
+
+export const updateDepartmentHandler = async (
+  request: FastifyRequest<{ Params: { id: string }; Body: { department_code?: string; name?: string; office_id?: number } }>,
+  reply: FastifyReply
+) => {
+  const id = Number(request.params.id);
+  if (Number.isNaN(id)) {
+    return reply.code(400).send({ message: 'invalid id' });
+  }
+  const parse = updateDepartmentSchema.safeParse(request.body);
+  if (!parse.success) {
+    return reply.code(400).send({ message: parse.error.message });
+  }
+  try {
+    const department = await departmentService.updateDepartment(id, parse.data);
+    if (!department) {
+      return reply.code(404).send({ message: 'not found' });
+    }
+    return reply.send({ data: department });
+  } catch (err) {
+    reply.log.error(err);
+    return reply.code(500).send({ message: 'internal server error' });
+  }
+};
+
+export const deleteDepartmentHandler = async (
+  request: FastifyRequest<{ Params: { id: string } }>,
+  reply: FastifyReply
+) => {
+  const id = Number(request.params.id);
+  if (Number.isNaN(id)) {
+    return reply.code(400).send({ message: 'invalid id' });
+  }
+  try {
+    const department = await departmentService.deleteDepartment(id);
+    if (!department) {
+      return reply.code(404).send({ message: 'not found' });
+    }
+    return reply.send({ data: department });
+  } catch (err) {
+    reply.log.error(err);
+    return reply.code(500).send({ message: 'internal server error' });
+  }
+};

--- a/src/backend/routes/departments.routes.ts
+++ b/src/backend/routes/departments.routes.ts
@@ -1,0 +1,16 @@
+import { FastifyInstance } from 'fastify';
+import {
+  getDepartmentsHandler,
+  getDepartmentHandler,
+  createDepartmentHandler,
+  updateDepartmentHandler,
+  deleteDepartmentHandler,
+} from '../controllers/departments.controller';
+
+export default async function departmentRoutes(fastify: FastifyInstance) {
+  fastify.get('/departments', { onRequest: [fastify.authenticate] }, getDepartmentsHandler);
+  fastify.get<{ Params: { id: string } }>('/departments/:id', { onRequest: [fastify.authenticate] }, getDepartmentHandler);
+  fastify.post('/departments', { onRequest: [fastify.authenticate] }, createDepartmentHandler);
+  fastify.put<{ Params: { id: string } }>('/departments/:id', { onRequest: [fastify.authenticate] }, updateDepartmentHandler);
+  fastify.delete<{ Params: { id: string } }>('/departments/:id', { onRequest: [fastify.authenticate] }, deleteDepartmentHandler);
+}

--- a/src/backend/schemas/departments.schema.ts
+++ b/src/backend/schemas/departments.schema.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+
+export const createDepartmentSchema = z.object({
+  department_code: z.string().min(1),
+  name: z.string().min(1),
+  office_id: z.number().int(),
+});
+
+export const updateDepartmentSchema = z.object({
+  department_code: z.string().min(1).optional(),
+  name: z.string().min(1).optional(),
+  office_id: z.number().int().optional(),
+});

--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -4,6 +4,7 @@ import authRoutes from './routes/auth.routes';
 import positionsRoutes from './routes/positions.routes';
 import officeRoutes from './routes/offices.routes';
 import userRoutes from './routes/users.routes';
+import departmentRoutes from './routes/departments.routes';
 import dbPlugin from './plugins/db';
 import jwtPlugin from './utils/jwt';
 
@@ -21,6 +22,7 @@ server.register(authRoutes);
 server.register(positionsRoutes);
 server.register(officeRoutes);
 server.register(userRoutes);
+server.register(departmentRoutes);
 
 const start = async () => {
   try {

--- a/src/backend/services/departments.service.ts
+++ b/src/backend/services/departments.service.ts
@@ -1,0 +1,75 @@
+import pool from '../utils/db';
+import { Department } from '../../shared/types';
+
+export const getDepartments = async (): Promise<Department[]> => {
+  const result = await pool.query<Department>(
+    'SELECT * FROM m_departments WHERE is_active = true ORDER BY id'
+  );
+  return result.rows;
+};
+
+export const getDepartmentById = async (
+  id: number
+): Promise<Department | null> => {
+  const result = await pool.query<Department>(
+    'SELECT * FROM m_departments WHERE id = $1 AND is_active = true',
+    [id]
+  );
+  return result.rows[0] || null;
+};
+
+export const createDepartment = async (data: {
+  department_code: string;
+  name: string;
+  office_id: number;
+}): Promise<Department> => {
+  const { department_code, name, office_id } = data;
+  const result = await pool.query<Department>(
+    'INSERT INTO m_departments (department_code, name, office_id, is_active, created_at, updated_at) VALUES ($1, $2, $3, true, now(), now()) RETURNING *',
+    [department_code, name, office_id]
+  );
+  return result.rows[0];
+};
+
+export const updateDepartment = async (
+  id: number,
+  data: { department_code?: string; name?: string; office_id?: number }
+): Promise<Department | null> => {
+  const fields: string[] = [];
+  const values: any[] = [];
+  let idx = 1;
+
+  if (data.department_code !== undefined) {
+    fields.push(`department_code = $${idx++}`);
+    values.push(data.department_code);
+  }
+  if (data.name !== undefined) {
+    fields.push(`name = $${idx++}`);
+    values.push(data.name);
+  }
+  if (data.office_id !== undefined) {
+    fields.push(`office_id = $${idx++}`);
+    values.push(data.office_id);
+  }
+
+  if (fields.length === 0) {
+    return null;
+  }
+
+  fields.push('updated_at = now()');
+  values.push(id);
+
+  const result = await pool.query<Department>(
+    `UPDATE m_departments SET ${fields.join(', ')} WHERE id = $${idx} AND is_active = true RETURNING *`,
+    values
+  );
+  return result.rows[0] || null;
+};
+
+export const deleteDepartment = async (id: number): Promise<Department | null> => {
+  const result = await pool.query<Department>(
+    'UPDATE m_departments SET is_active = false, updated_at = now() WHERE id = $1 AND is_active = true RETURNING *',
+    [id]
+  );
+  return result.rows[0] || null;
+};

--- a/src/shared/types/index.d.ts
+++ b/src/shared/types/index.d.ts
@@ -34,6 +34,16 @@ export interface Position {
   updated_at: Date;
 }
 
+export interface Department {
+  id: number;
+  department_code: string;
+  name: string;
+  office_id: number;
+  is_active: boolean;
+  created_at: Date;
+  updated_at: Date;
+}
+
 declare module 'fastify' {
   interface FastifyInstance {
     pg: Pool;


### PR DESCRIPTION
## Summary
- add Department type definition
- implement department service, controller, routes, and schema
- register department routes in server

## Testing
- `npm install`
- `npm run build` *(fails: TypeScript compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_6879e886d8a083318020a0707dd38b1c