### PR TITLE
Implement work pattern API

### DIFF
--- a/src/backend/controllers/work_patterns.controller.ts
+++ b/src/backend/controllers/work_patterns.controller.ts
@@ -1,0 +1,106 @@
+import { FastifyReply, FastifyRequest } from 'fastify';
+import {
+  createWorkPattern,
+  deleteWorkPattern,
+  getWorkPattern,
+  getWorkPatterns,
+  updateWorkPattern,
+} from '../services/work_patterns.service';
+import {
+  createWorkPatternSchema,
+  updateWorkPatternSchema,
+} from '../schemas/work_patterns.schema';
+
+export const getWorkPatternsHandler = async (
+  _request: FastifyRequest,
+  reply: FastifyReply
+) => {
+  try {
+    const patterns = await getWorkPatterns();
+    return reply.send({ data: patterns });
+  } catch (err) {
+    reply.log.error(err);
+    return reply.code(500).send({ message: 'internal server error' });
+  }
+};
+
+export const getWorkPatternHandler = async (
+  request: FastifyRequest<{ Params: { id: string } }>,
+  reply: FastifyReply
+) => {
+  const id = Number(request.params.id);
+  if (Number.isNaN(id)) {
+    return reply.code(400).send({ message: 'invalid id' });
+  }
+  try {
+    const pattern = await getWorkPattern(id);
+    if (!pattern) {
+      return reply.code(404).send({ message: 'not found' });
+    }
+    return reply.send({ data: pattern });
+  } catch (err) {
+    reply.log.error(err);
+    return reply.code(500).send({ message: 'internal server error' });
+  }
+};
+
+export const createWorkPatternHandler = async (
+  request: FastifyRequest,
+  reply: FastifyReply
+) => {
+  const parse = createWorkPatternSchema.safeParse(request.body);
+  if (!parse.success) {
+    return reply.code(400).send({ message: parse.error.message });
+  }
+  try {
+    const pattern = await createWorkPattern(parse.data);
+    return reply.code(201).send({ data: pattern });
+  } catch (err) {
+    reply.log.error(err);
+    return reply.code(500).send({ message: 'internal server error' });
+  }
+};
+
+export const updateWorkPatternHandler = async (
+  request: FastifyRequest<{ Params: { id: string } }>,
+  reply: FastifyReply
+) => {
+  const id = Number(request.params.id);
+  if (Number.isNaN(id)) {
+    return reply.code(400).send({ message: 'invalid id' });
+  }
+  const parse = updateWorkPatternSchema.safeParse(request.body);
+  if (!parse.success) {
+    return reply.code(400).send({ message: parse.error.message });
+  }
+  try {
+    const pattern = await updateWorkPattern(id, parse.data);
+    if (!pattern) {
+      return reply.code(404).send({ message: 'not found' });
+    }
+    return reply.send({ data: pattern });
+  } catch (err) {
+    reply.log.error(err);
+    return reply.code(500).send({ message: 'internal server error' });
+  }
+};
+
+export const deleteWorkPatternHandler = async (
+  request: FastifyRequest<{ Params: { id: string } }>,
+  reply: FastifyReply
+) => {
+  const id = Number(request.params.id);
+  if (Number.isNaN(id)) {
+    return reply.code(400).send({ message: 'invalid id' });
+  }
+  try {
+    const pattern = await deleteWorkPattern(id);
+    if (!pattern) {
+      return reply.code(404).send({ message: 'not found' });
+    }
+    return reply.send({ data: pattern });
+  } catch (err) {
+    reply.log.error(err);
+    return reply.code(500).send({ message: 'internal server error' });
+  }
+};

--- a/src/backend/routes/work_patterns.routes.ts
+++ b/src/backend/routes/work_patterns.routes.ts
@@ -1,0 +1,16 @@
+import { FastifyInstance } from 'fastify';
+import {
+  getWorkPatternsHandler,
+  getWorkPatternHandler,
+  createWorkPatternHandler,
+  updateWorkPatternHandler,
+  deleteWorkPatternHandler,
+} from '../controllers/work_patterns.controller';
+
+export default async function workPatternRoutes(fastify: FastifyInstance) {
+  fastify.get('/work-patterns', { onRequest: [fastify.authenticate] }, getWorkPatternsHandler);
+  fastify.get<{ Params: { id: string } }>('/work-patterns/:id', { onRequest: [fastify.authenticate] }, getWorkPatternHandler);
+  fastify.post('/work-patterns', { onRequest: [fastify.authenticate] }, createWorkPatternHandler);
+  fastify.put<{ Params: { id: string } }>('/work-patterns/:id', { onRequest: [fastify.authenticate] }, updateWorkPatternHandler);
+  fastify.delete<{ Params: { id: string } }>('/work-patterns/:id', { onRequest: [fastify.authenticate] }, deleteWorkPatternHandler);
+}

--- a/src/backend/schemas/work_patterns.schema.ts
+++ b/src/backend/schemas/work_patterns.schema.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+export const createWorkPatternSchema = z.object({
+  pattern_code: z.string().min(1),
+  name: z.string().min(1),
+  start_time: z.string().min(1),
+  end_time: z.string().min(1),
+  break_minutes: z.number().int().nonnegative(),
+  is_active: z.boolean().optional().default(true),
+});
+
+export const updateWorkPatternSchema = z.object({
+  pattern_code: z.string().min(1).optional(),
+  name: z.string().min(1).optional(),
+  start_time: z.string().min(1).optional(),
+  end_time: z.string().min(1).optional(),
+  break_minutes: z.number().int().nonnegative().optional(),
+  is_active: z.boolean().optional(),
+});

--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -9,6 +9,7 @@ import departmentsRoutes from './routes/departments.routes';
 import dbPlugin from './plugins/db';
 import jwtPlugin from './utils/jwt';
 import employeeRoutes from './routes/employees.routes';
+import workPatternRoutes from './routes/work_patterns.routes';
 
 dotenv.config();
 
@@ -28,6 +29,7 @@ server.register(roleRoutes);
 server.register(departmentsRoutes);
 server.register(employeeRoutes); // 従業員マスタ
 server.register(userRoutes);     // ユーザーマスタ
+server.register(workPatternRoutes);
 
 const start = async () => {
   try {

--- a/src/backend/services/work_patterns.service.ts
+++ b/src/backend/services/work_patterns.service.ts
@@ -1,0 +1,95 @@
+import pool from '../utils/db';
+import { WorkPattern } from '../../shared/types';
+
+export const getWorkPatterns = async (): Promise<WorkPattern[]> => {
+  const result = await pool.query<WorkPattern>(
+    'SELECT * FROM m_work_patterns WHERE is_active = true ORDER BY id'
+  );
+  return result.rows;
+};
+
+export const getWorkPattern = async (id: number): Promise<WorkPattern | null> => {
+  const result = await pool.query<WorkPattern>(
+    'SELECT * FROM m_work_patterns WHERE id = $1 AND is_active = true',
+    [id]
+  );
+  return result.rows[0] || null;
+};
+
+export const createWorkPattern = async (data: {
+  pattern_code: string;
+  name: string;
+  start_time: string;
+  end_time: string;
+  break_minutes: number;
+  is_active?: boolean;
+}): Promise<WorkPattern> => {
+  const { pattern_code, name, start_time, end_time, break_minutes, is_active } = data;
+  const result = await pool.query<WorkPattern>(
+    'INSERT INTO m_work_patterns (pattern_code, name, start_time, end_time, break_minutes, is_active, created_at, updated_at) VALUES ($1, $2, $3, $4, $5, $6, now(), now()) RETURNING *',
+    [pattern_code, name, start_time, end_time, break_minutes, is_active ?? true]
+  );
+  return result.rows[0];
+};
+
+export const updateWorkPattern = async (
+  id: number,
+  data: {
+    pattern_code?: string;
+    name?: string;
+    start_time?: string;
+    end_time?: string;
+    break_minutes?: number;
+    is_active?: boolean;
+  }
+): Promise<WorkPattern | null> => {
+  const fields: string[] = [];
+  const values: any[] = [];
+  let idx = 1;
+
+  if (data.pattern_code !== undefined) {
+    fields.push(`pattern_code = $${idx++}`);
+    values.push(data.pattern_code);
+  }
+  if (data.name !== undefined) {
+    fields.push(`name = $${idx++}`);
+    values.push(data.name);
+  }
+  if (data.start_time !== undefined) {
+    fields.push(`start_time = $${idx++}`);
+    values.push(data.start_time);
+  }
+  if (data.end_time !== undefined) {
+    fields.push(`end_time = $${idx++}`);
+    values.push(data.end_time);
+  }
+  if (data.break_minutes !== undefined) {
+    fields.push(`break_minutes = $${idx++}`);
+    values.push(data.break_minutes);
+  }
+  if (data.is_active !== undefined) {
+    fields.push(`is_active = $${idx++}`);
+    values.push(data.is_active);
+  }
+
+  if (fields.length === 0) {
+    return null;
+  }
+
+  fields.push('updated_at = now()');
+  values.push(id);
+
+  const result = await pool.query<WorkPattern>(
+    `UPDATE m_work_patterns SET ${fields.join(', ')} WHERE id = $${idx} RETURNING *`,
+    values
+  );
+  return result.rows[0] || null;
+};
+
+export const deleteWorkPattern = async (id: number): Promise<WorkPattern | null> => {
+  const result = await pool.query<WorkPattern>(
+    'UPDATE m_work_patterns SET is_active = false, updated_at = now() WHERE id = $1 RETURNING *',
+    [id]
+  );
+  return result.rows[0] || null;
+};

--- a/src/shared/types/index.d.ts
+++ b/src/shared/types/index.d.ts
@@ -64,6 +64,18 @@ export interface Department {
   updated_at: string;
 }
 
+export interface WorkPattern {
+  id: number;
+  pattern_code: string;
+  name: string;
+  start_time: string;
+  end_time: string;
+  break_minutes: number;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
 declare module 'fastify' {
   interface FastifyInstance {
     pg: Pool;


### PR DESCRIPTION
## Summary
- add `WorkPattern` type
- add work pattern schemas, service, controller, and routes
- register work pattern routes in server

## Testing
- `npm run build` *(fails: TS2345 in `offices.routes.ts`)*

------
https://chatgpt.com/codex/tasks/task_e_6879f3db89e48331925af0a1dddf0b0c