### PR TITLE
Implement attendance records CRUD API

### DIFF
--- a/src/backend/controllers/attendance_records.controller.ts
+++ b/src/backend/controllers/attendance_records.controller.ts
@@ -1,0 +1,105 @@
+import { FastifyReply, FastifyRequest } from 'fastify';
+import {
+  createAttendanceRecordSchema,
+  updateAttendanceRecordSchema,
+} from '../schemas/attendance_records.schema';
+import * as attendanceService from '../services/attendance_records.service';
+
+export const getAttendanceRecordsHandler = async (
+  request: FastifyRequest<{ Querystring: { employee_id?: string; start_date?: string; end_date?: string } }>,
+  reply: FastifyReply
+) => {
+  const { employee_id, start_date, end_date } = request.query;
+  try {
+    const records = await attendanceService.getAttendanceRecords({
+      employee_id: employee_id ? Number(employee_id) : undefined,
+      start_date,
+      end_date,
+    });
+    return reply.send({ data: records });
+  } catch (err) {
+    reply.log.error(err);
+    return reply.code(500).send({ message: 'internal server error' });
+  }
+};
+
+export const getAttendanceRecordHandler = async (
+  request: FastifyRequest<{ Params: { id: string } }>,
+  reply: FastifyReply
+) => {
+  const id = Number(request.params.id);
+  if (Number.isNaN(id)) {
+    return reply.code(400).send({ message: 'invalid id' });
+  }
+  try {
+    const record = await attendanceService.getAttendanceRecord(id);
+    if (!record) {
+      return reply.code(404).send({ message: 'not found' });
+    }
+    return reply.send({ data: record });
+  } catch (err) {
+    reply.log.error(err);
+    return reply.code(500).send({ message: 'internal server error' });
+  }
+};
+
+export const createAttendanceRecordHandler = async (
+  request: FastifyRequest,
+  reply: FastifyReply
+) => {
+  const parse = createAttendanceRecordSchema.safeParse(request.body);
+  if (!parse.success) {
+    return reply.code(400).send({ message: parse.error.message });
+  }
+  try {
+    const record = await attendanceService.createAttendanceRecord(parse.data);
+    return reply.code(201).send({ data: record });
+  } catch (err) {
+    reply.log.error(err);
+    return reply.code(500).send({ message: 'internal server error' });
+  }
+};
+
+export const updateAttendanceRecordHandler = async (
+  request: FastifyRequest<{ Params: { id: string } }>,
+  reply: FastifyReply
+) => {
+  const id = Number(request.params.id);
+  if (Number.isNaN(id)) {
+    return reply.code(400).send({ message: 'invalid id' });
+  }
+  const parse = updateAttendanceRecordSchema.safeParse(request.body);
+  if (!parse.success) {
+    return reply.code(400).send({ message: parse.error.message });
+  }
+  try {
+    const record = await attendanceService.updateAttendanceRecord(id, parse.data);
+    if (!record) {
+      return reply.code(404).send({ message: 'not found' });
+    }
+    return reply.send({ data: record });
+  } catch (err) {
+    reply.log.error(err);
+    return reply.code(500).send({ message: 'internal server error' });
+  }
+};
+
+export const deleteAttendanceRecordHandler = async (
+  request: FastifyRequest<{ Params: { id: string } }>,
+  reply: FastifyReply
+) => {
+  const id = Number(request.params.id);
+  if (Number.isNaN(id)) {
+    return reply.code(400).send({ message: 'invalid id' });
+  }
+  try {
+    const record = await attendanceService.deleteAttendanceRecord(id);
+    if (!record) {
+      return reply.code(404).send({ message: 'not found' });
+    }
+    return reply.send({ data: record });
+  } catch (err) {
+    reply.log.error(err);
+    return reply.code(500).send({ message: 'internal server error' });
+  }
+};

--- a/src/backend/routes/attendance_records.routes.ts
+++ b/src/backend/routes/attendance_records.routes.ts
@@ -1,0 +1,18 @@
+import { FastifyInstance } from 'fastify';
+import {
+  getAttendanceRecordsHandler,
+  getAttendanceRecordHandler,
+  createAttendanceRecordHandler,
+  updateAttendanceRecordHandler,
+  deleteAttendanceRecordHandler,
+} from '../controllers/attendance_records.controller';
+
+export default async function attendanceRecordsRoutes(fastify: FastifyInstance) {
+  fastify.get<{
+    Querystring: { employee_id?: string; start_date?: string; end_date?: string };
+  }>('/attendance-records', { onRequest: [fastify.authenticate] }, getAttendanceRecordsHandler);
+  fastify.get<{ Params: { id: string } }>('/attendance-records/:id', { onRequest: [fastify.authenticate] }, getAttendanceRecordHandler);
+  fastify.post('/attendance-records', { onRequest: [fastify.authenticate] }, createAttendanceRecordHandler);
+  fastify.put<{ Params: { id: string } }>('/attendance-records/:id', { onRequest: [fastify.authenticate] }, updateAttendanceRecordHandler);
+  fastify.delete<{ Params: { id: string } }>('/attendance-records/:id', { onRequest: [fastify.authenticate] }, deleteAttendanceRecordHandler);
+}

--- a/src/backend/schemas/attendance_records.schema.ts
+++ b/src/backend/schemas/attendance_records.schema.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod';
+
+export const createAttendanceRecordSchema = z.object({
+  employee_id: z.number().int(),
+  work_date: z.string(),
+  clock_in: z.string().optional(),
+  clock_out: z.string().optional(),
+  is_manual: z.boolean().optional().default(false),
+  remarks: z.string().optional(),
+});
+
+export const updateAttendanceRecordSchema = z.object({
+  employee_id: z.number().int().optional(),
+  work_date: z.string().optional(),
+  clock_in: z.string().optional().nullable(),
+  clock_out: z.string().optional().nullable(),
+  is_manual: z.boolean().optional(),
+  remarks: z.string().optional().nullable(),
+  is_active: z.boolean().optional(),
+});

--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -7,6 +7,7 @@ import userRoutes from './routes/users.routes';
 import userRolesRoutes from './routes/userRoles.routes';
 import roleRoutes from './routes/roles.routes';
 import departmentsRoutes from './routes/departments.routes';
+import attendanceRecordsRoutes from './routes/attendance_records.routes';
 import dbPlugin from './plugins/db';
 import jwtPlugin from './utils/jwt';
 import employeeRoutes from './routes/employees.routes';
@@ -32,6 +33,7 @@ server.register(employeeRoutes); // 従業員マスタ
 server.register(userRoutes);     // ユーザーマスタ
 server.register(workPatternRoutes);
 server.register(userRolesRoutes); // ユーザーロール
+server.register(attendanceRecordsRoutes);
 
 const start = async () => {
   try {

--- a/src/backend/services/attendance_records.service.ts
+++ b/src/backend/services/attendance_records.service.ts
@@ -1,0 +1,134 @@
+import pool from '../utils/db';
+import { AttendanceRecord } from '../../shared/types';
+
+export const getAttendanceRecords = async (filters: {
+  employee_id?: number;
+  start_date?: string;
+  end_date?: string;
+} = {}): Promise<AttendanceRecord[]> => {
+  const conditions: string[] = ['is_active = true'];
+  const values: any[] = [];
+  let idx = 1;
+
+  if (filters.employee_id !== undefined) {
+    conditions.push(`employee_id = $${idx++}`);
+    values.push(filters.employee_id);
+  }
+  if (filters.start_date !== undefined) {
+    conditions.push(`work_date >= $${idx++}`);
+    values.push(filters.start_date);
+  }
+  if (filters.end_date !== undefined) {
+    conditions.push(`work_date <= $${idx++}`);
+    values.push(filters.end_date);
+  }
+
+  const where = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
+  const result = await pool.query<AttendanceRecord>(
+    `SELECT * FROM t_attendance_records ${where} ORDER BY id`,
+    values
+  );
+  return result.rows;
+};
+
+export const getAttendanceRecord = async (
+  id: number
+): Promise<AttendanceRecord | null> => {
+  const result = await pool.query<AttendanceRecord>(
+    'SELECT * FROM t_attendance_records WHERE id = $1 AND is_active = true',
+    [id]
+  );
+  return result.rows[0] || null;
+};
+
+export const createAttendanceRecord = async (data: {
+  employee_id: number;
+  work_date: string;
+  clock_in?: string;
+  clock_out?: string;
+  is_manual?: boolean;
+  remarks?: string;
+}): Promise<AttendanceRecord> => {
+  const {
+    employee_id,
+    work_date,
+    clock_in = null,
+    clock_out = null,
+    is_manual = false,
+    remarks = null,
+  } = data;
+  const result = await pool.query<AttendanceRecord>(
+    'INSERT INTO t_attendance_records (employee_id, work_date, clock_in, clock_out, is_manual, remarks, is_active, created_at, updated_at) VALUES ($1, $2, $3, $4, $5, $6, true, now(), now()) RETURNING *',
+    [employee_id, work_date, clock_in, clock_out, is_manual, remarks]
+  );
+  return result.rows[0];
+};
+
+export const updateAttendanceRecord = async (
+  id: number,
+  data: {
+    employee_id?: number;
+    work_date?: string;
+    clock_in?: string | null;
+    clock_out?: string | null;
+    is_manual?: boolean;
+    remarks?: string | null;
+    is_active?: boolean;
+  }
+): Promise<AttendanceRecord | null> => {
+  const fields: string[] = [];
+  const values: any[] = [];
+  let idx = 1;
+
+  if (data.employee_id !== undefined) {
+    fields.push(`employee_id = $${idx++}`);
+    values.push(data.employee_id);
+  }
+  if (data.work_date !== undefined) {
+    fields.push(`work_date = $${idx++}`);
+    values.push(data.work_date);
+  }
+  if (data.clock_in !== undefined) {
+    fields.push(`clock_in = $${idx++}`);
+    values.push(data.clock_in);
+  }
+  if (data.clock_out !== undefined) {
+    fields.push(`clock_out = $${idx++}`);
+    values.push(data.clock_out);
+  }
+  if (data.is_manual !== undefined) {
+    fields.push(`is_manual = $${idx++}`);
+    values.push(data.is_manual);
+  }
+  if (data.remarks !== undefined) {
+    fields.push(`remarks = $${idx++}`);
+    values.push(data.remarks);
+  }
+  if (data.is_active !== undefined) {
+    fields.push(`is_active = $${idx++}`);
+    values.push(data.is_active);
+  }
+
+  if (fields.length === 0) {
+    return null;
+  }
+
+  fields.push('updated_at = now()');
+  values.push(id);
+
+  const result = await pool.query<AttendanceRecord>(
+    `UPDATE t_attendance_records SET ${fields.join(', ')} WHERE id = $${idx} RETURNING *`,
+    values
+  );
+  return result.rows[0] || null;
+};
+
+export const deleteAttendanceRecord = async (
+  id: number
+): Promise<AttendanceRecord | null> => {
+  const result = await pool.query<AttendanceRecord>(
+    'UPDATE t_attendance_records SET is_active = false, updated_at = now() WHERE id = $1 RETURNING *',
+    [id]
+  );
+  return result.rows[0] || null;
+};

--- a/src/shared/types/index.d.ts
+++ b/src/shared/types/index.d.ts
@@ -78,3 +78,16 @@ export interface Department {
   name: string;
   office_id: string;
 }
+
+export interface AttendanceRecord {
+  id: number;
+  employee_id: number;
+  work_date: string;
+  clock_in: string | null;
+  clock_out: string | null;
+  is_manual: boolean;
+  remarks: string | null;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}


### PR DESCRIPTION
## Summary
- add AttendanceRecord interface to shared types
- implement attendance record schemas
- add service layer for attendance records
- create controller with CRUD handlers
- define routes and register them in the server

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6879faffaccc8331ad42c3a354359f7c