### PR TITLE
Implement attendance record CRUD API

### DIFF
--- a/src/backend/controllers/attendance_records.controller.ts
+++ b/src/backend/controllers/attendance_records.controller.ts
@@ -1,0 +1,111 @@
+import { FastifyReply, FastifyRequest } from 'fastify';
+import {
+  createAttendanceRecord,
+  deleteAttendanceRecord,
+  getAttendanceRecord,
+  getAttendanceRecords,
+  updateAttendanceRecord,
+} from '../services/attendance_records.service';
+import {
+  createAttendanceRecordSchema,
+  updateAttendanceRecordSchema,
+} from '../schemas/attendance_records.schema';
+
+export const getAttendanceRecordsHandler = async (
+  request: FastifyRequest,
+  reply: FastifyReply
+) => {
+  const params = request.query as {
+    employee_id?: string;
+    start_date?: string;
+    end_date?: string;
+  };
+  try {
+    const records = await getAttendanceRecords(params);
+    return reply.send({ data: records });
+  } catch (err) {
+    reply.log.error(err);
+    return reply.code(500).send({ message: 'internal server error' });
+  }
+};
+
+export const getAttendanceRecordHandler = async (
+  request: FastifyRequest<{ Params: { id: string } }>,
+  reply: FastifyReply
+) => {
+  const id = request.params.id;
+  if (!id) {
+    return reply.code(400).send({ message: 'invalid id' });
+  }
+  try {
+    const record = await getAttendanceRecord(id);
+    if (!record) {
+      return reply.code(404).send({ message: 'not found' });
+    }
+    return reply.send({ data: record });
+  } catch (err) {
+    reply.log.error(err);
+    return reply.code(500).send({ message: 'internal server error' });
+  }
+};
+
+export const createAttendanceRecordHandler = async (
+  request: FastifyRequest,
+  reply: FastifyReply
+) => {
+  const parse = createAttendanceRecordSchema.safeParse(request.body);
+  if (!parse.success) {
+    return reply.code(400).send({ message: parse.error.message });
+  }
+  try {
+    const record = await createAttendanceRecord(parse.data);
+    return reply.code(201).send({ data: record });
+  } catch (err) {
+    reply.log.error(err);
+    return reply.code(500).send({ message: 'internal server error' });
+  }
+};
+
+export const updateAttendanceRecordHandler = async (
+  request: FastifyRequest<{ Params: { id: string } }>,
+  reply: FastifyReply
+) => {
+  const id = request.params.id;
+  if (!id) {
+    return reply.code(400).send({ message: 'invalid id' });
+  }
+  const parse = updateAttendanceRecordSchema.safeParse(request.body);
+  if (!parse.success) {
+    return reply.code(400).send({ message: parse.error.message });
+  }
+  try {
+    const record = await updateAttendanceRecord(id, parse.data);
+    if (!record) {
+      return reply.code(404).send({ message: 'not found' });
+    }
+    return reply.send({ data: record });
+  } catch (err) {
+    reply.log.error(err);
+    return reply.code(500).send({ message: 'internal server error' });
+  }
+};
+
+export const deleteAttendanceRecordHandler = async (
+  request: FastifyRequest<{ Params: { id: string } }>,
+  reply: FastifyReply
+) => {
+  const id = request.params.id;
+  if (!id) {
+    return reply.code(400).send({ message: 'invalid id' });
+  }
+  try {
+    const record = await deleteAttendanceRecord(id);
+    if (!record) {
+      return reply.code(404).send({ message: 'not found' });
+    }
+    return reply.send({ data: record });
+  } catch (err) {
+    reply.log.error(err);
+    return reply.code(500).send({ message: 'internal server error' });
+  }
+};

--- a/src/backend/routes/attendance_records.routes.ts
+++ b/src/backend/routes/attendance_records.routes.ts
@@ -1,0 +1,16 @@
+import { FastifyInstance } from 'fastify';
+import {
+  getAttendanceRecordsHandler,
+  getAttendanceRecordHandler,
+  createAttendanceRecordHandler,
+  updateAttendanceRecordHandler,
+  deleteAttendanceRecordHandler,
+} from '../controllers/attendance_records.controller';
+
+export default async function attendanceRecordRoutes(fastify: FastifyInstance) {
+  fastify.get('/attendance-records', { onRequest: [fastify.authenticate] }, getAttendanceRecordsHandler);
+  fastify.get<{ Params: { id: string } }>('/attendance-records/:id', { onRequest: [fastify.authenticate] }, getAttendanceRecordHandler);
+  fastify.post('/attendance-records', { onRequest: [fastify.authenticate] }, createAttendanceRecordHandler);
+  fastify.put<{ Params: { id: string } }>('/attendance-records/:id', { onRequest: [fastify.authenticate] }, updateAttendanceRecordHandler);
+  fastify.delete<{ Params: { id: string } }>('/attendance-records/:id', { onRequest: [fastify.authenticate] }, deleteAttendanceRecordHandler);
+}

--- a/src/backend/schemas/attendance_records.schema.ts
+++ b/src/backend/schemas/attendance_records.schema.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod';
+
+export const createAttendanceRecordSchema = z.object({
+  employee_id: z.string().uuid(),
+  work_date: z.string(),
+  clock_in: z.string().optional(),
+  clock_out: z.string().optional(),
+  is_manual: z.boolean().optional().default(false),
+  remarks: z.string().optional(),
+});
+
+export const updateAttendanceRecordSchema = z.object({
+  employee_id: z.string().uuid().optional(),
+  work_date: z.string().optional(),
+  clock_in: z.string().nullable().optional(),
+  clock_out: z.string().nullable().optional(),
+  is_manual: z.boolean().optional(),
+  remarks: z.string().optional(),
+  is_active: z.boolean().optional(),
+});

--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -11,6 +11,7 @@ import dbPlugin from './plugins/db';
 import jwtPlugin from './utils/jwt';
 import employeeRoutes from './routes/employees.routes';
 import workPatternRoutes from './routes/work_patterns.routes';
+import attendanceRecordRoutes from './routes/attendance_records.routes';
 
 dotenv.config();
 
@@ -31,6 +32,7 @@ server.register(departmentsRoutes);
 server.register(employeeRoutes); // 従業員マスタ
 server.register(userRoutes);     // ユーザーマスタ
 server.register(workPatternRoutes);
+server.register(attendanceRecordRoutes); // 勤怠打刻
 server.register(userRolesRoutes); // ユーザーロール
 
 const start = async () => {

--- a/src/backend/services/attendance_records.service.ts
+++ b/src/backend/services/attendance_records.service.ts
@@ -1,0 +1,140 @@
+import pool from '../utils/db';
+import { AttendanceRecord } from '../../shared/types';
+
+interface GetRecordsParams {
+  employee_id?: string;
+  start_date?: string;
+  end_date?: string;
+}
+
+export const getAttendanceRecords = async (
+  params: GetRecordsParams
+): Promise<AttendanceRecord[]> => {
+  const conditions: string[] = ['is_active = true'];
+  const values: any[] = [];
+  let idx = 1;
+
+  if (params.employee_id) {
+    conditions.push(`employee_id = $${idx++}`);
+    values.push(params.employee_id);
+  }
+  if (params.start_date) {
+    conditions.push(`work_date >= $${idx++}`);
+    values.push(params.start_date);
+  }
+  if (params.end_date) {
+    conditions.push(`work_date <= $${idx++}`);
+    values.push(params.end_date);
+  }
+
+  const where = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
+  const result = await pool.query<AttendanceRecord>(
+    `SELECT * FROM t_attendance_records ${where} ORDER BY work_date DESC, id`,
+    values
+  );
+  return result.rows;
+};
+
+export const getAttendanceRecord = async (
+  id: string
+): Promise<AttendanceRecord | null> => {
+  const result = await pool.query<AttendanceRecord>(
+    'SELECT * FROM t_attendance_records WHERE id = $1 AND is_active = true',
+    [id]
+  );
+  return result.rows[0] || null;
+};
+
+export const createAttendanceRecord = async (
+  data: {
+    employee_id: string;
+    work_date: string;
+    clock_in?: string | null;
+    clock_out?: string | null;
+    is_manual?: boolean;
+    remarks?: string | null;
+  }
+): Promise<AttendanceRecord> => {
+  const {
+    employee_id,
+    work_date,
+    clock_in = null,
+    clock_out = null,
+    is_manual = false,
+    remarks = null,
+  } = data;
+  const result = await pool.query<AttendanceRecord>(
+    'INSERT INTO t_attendance_records (employee_id, work_date, clock_in, clock_out, is_manual, remarks, is_active, created_at, updated_at) VALUES ($1, $2, $3, $4, $5, $6, true, now(), now()) RETURNING *',
+    [employee_id, work_date, clock_in, clock_out, is_manual, remarks]
+  );
+  return result.rows[0];
+};
+
+export const updateAttendanceRecord = async (
+  id: string,
+  data: {
+    employee_id?: string;
+    work_date?: string;
+    clock_in?: string | null;
+    clock_out?: string | null;
+    is_manual?: boolean;
+    remarks?: string | null;
+    is_active?: boolean;
+  }
+): Promise<AttendanceRecord | null> => {
+  const fields: string[] = [];
+  const values: any[] = [];
+  let idx = 1;
+
+  if (data.employee_id !== undefined) {
+    fields.push(`employee_id = $${idx++}`);
+    values.push(data.employee_id);
+  }
+  if (data.work_date !== undefined) {
+    fields.push(`work_date = $${idx++}`);
+    values.push(data.work_date);
+  }
+  if (data.clock_in !== undefined) {
+    fields.push(`clock_in = $${idx++}`);
+    values.push(data.clock_in);
+  }
+  if (data.clock_out !== undefined) {
+    fields.push(`clock_out = $${idx++}`);
+    values.push(data.clock_out);
+  }
+  if (data.is_manual !== undefined) {
+    fields.push(`is_manual = $${idx++}`);
+    values.push(data.is_manual);
+  }
+  if (data.remarks !== undefined) {
+    fields.push(`remarks = $${idx++}`);
+    values.push(data.remarks);
+  }
+  if (data.is_active !== undefined) {
+    fields.push(`is_active = $${idx++}`);
+    values.push(data.is_active);
+  }
+
+  if (fields.length === 0) {
+    return null;
+  }
+
+  fields.push('updated_at = now()');
+  values.push(id);
+
+  const result = await pool.query<AttendanceRecord>(
+    `UPDATE t_attendance_records SET ${fields.join(', ')} WHERE id = $${idx} RETURNING *`,
+    values
+  );
+  return result.rows[0] || null;
+};
+
+export const deleteAttendanceRecord = async (
+  id: string
+): Promise<AttendanceRecord | null> => {
+  const result = await pool.query<AttendanceRecord>(
+    'UPDATE t_attendance_records SET is_active = false, updated_at = now() WHERE id = $1 RETURNING *',
+    [id]
+  );
+  return result.rows[0] || null;
+};

--- a/src/shared/types/attendance_records.ts
+++ b/src/shared/types/attendance_records.ts
@@ -1,0 +1,12 @@
+export interface AttendanceRecord {
+  id: string;
+  employee_id: string;
+  work_date: string;
+  clock_in: string | null;
+  clock_out: string | null;
+  is_manual: boolean;
+  remarks: string | null;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}

--- a/src/shared/types/index.d.ts
+++ b/src/shared/types/index.d.ts
@@ -78,3 +78,16 @@ export interface Department {
   name: string;
   office_id: string;
 }
+
+export interface AttendanceRecord {
+  id: string;
+  employee_id: string;
+  work_date: string;
+  clock_in: string | null;
+  clock_out: string | null;
+  is_manual: boolean;
+  remarks: string | null;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}


### PR DESCRIPTION
## Summary
- add AttendanceRecord type
- implement CRUD service, controller, and schema for attendance records
- expose routes and register them with the server

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6879faffaccc8331ad42c3a354359f7c