### PR TITLE
Implement attendance summaries CRUD API

### DIFF
--- a/src/backend/controllers/attendance_summaries.controller.ts
+++ b/src/backend/controllers/attendance_summaries.controller.ts
@@ -1,0 +1,105 @@
+import { FastifyReply, FastifyRequest } from 'fastify';
+import {
+  createAttendanceSummarySchema,
+  updateAttendanceSummarySchema,
+} from '../schemas/attendance_summaries.schema';
+import * as summaryService from '../services/attendance_summaries.service';
+
+export const getAttendanceSummariesHandler = async (
+  request: FastifyRequest<{ Querystring: { employee_id?: string; start_date?: string; end_date?: string } }>,
+  reply: FastifyReply
+) => {
+  const { employee_id, start_date, end_date } = request.query;
+  try {
+    const summaries = await summaryService.getAttendanceSummaries({
+      employee_id: employee_id ? Number(employee_id) : undefined,
+      start_date,
+      end_date,
+    });
+    return reply.send({ data: summaries });
+  } catch (err) {
+    reply.log.error(err);
+    return reply.code(500).send({ message: 'internal server error' });
+  }
+};
+
+export const getAttendanceSummaryHandler = async (
+  request: FastifyRequest<{ Params: { id: string } }>,
+  reply: FastifyReply
+) => {
+  const id = Number(request.params.id);
+  if (Number.isNaN(id)) {
+    return reply.code(400).send({ message: 'invalid id' });
+  }
+  try {
+    const summary = await summaryService.getAttendanceSummary(id);
+    if (!summary) {
+      return reply.code(404).send({ message: 'not found' });
+    }
+    return reply.send({ data: summary });
+  } catch (err) {
+    reply.log.error(err);
+    return reply.code(500).send({ message: 'internal server error' });
+  }
+};
+
+export const createAttendanceSummaryHandler = async (
+  request: FastifyRequest,
+  reply: FastifyReply
+) => {
+  const parse = createAttendanceSummarySchema.safeParse(request.body);
+  if (!parse.success) {
+    return reply.code(400).send({ message: parse.error.message });
+  }
+  try {
+    const summary = await summaryService.createAttendanceSummary(parse.data);
+    return reply.code(201).send({ data: summary });
+  } catch (err) {
+    reply.log.error(err);
+    return reply.code(500).send({ message: 'internal server error' });
+  }
+};
+
+export const updateAttendanceSummaryHandler = async (
+  request: FastifyRequest<{ Params: { id: string } }>,
+  reply: FastifyReply
+) => {
+  const id = Number(request.params.id);
+  if (Number.isNaN(id)) {
+    return reply.code(400).send({ message: 'invalid id' });
+  }
+  const parse = updateAttendanceSummarySchema.safeParse(request.body);
+  if (!parse.success) {
+    return reply.code(400).send({ message: parse.error.message });
+  }
+  try {
+    const summary = await summaryService.updateAttendanceSummary(id, parse.data);
+    if (!summary) {
+      return reply.code(404).send({ message: 'not found' });
+    }
+    return reply.send({ data: summary });
+  } catch (err) {
+    reply.log.error(err);
+    return reply.code(500).send({ message: 'internal server error' });
+  }
+};
+
+export const deleteAttendanceSummaryHandler = async (
+  request: FastifyRequest<{ Params: { id: string } }>,
+  reply: FastifyReply
+) => {
+  const id = Number(request.params.id);
+  if (Number.isNaN(id)) {
+    return reply.code(400).send({ message: 'invalid id' });
+  }
+  try {
+    const summary = await summaryService.deleteAttendanceSummary(id);
+    if (!summary) {
+      return reply.code(404).send({ message: 'not found' });
+    }
+    return reply.send({ data: summary });
+  } catch (err) {
+    reply.log.error(err);
+    return reply.code(500).send({ message: 'internal server error' });
+  }
+};

--- a/src/backend/routes/attendance_summaries.routes.ts
+++ b/src/backend/routes/attendance_summaries.routes.ts
@@ -1,0 +1,18 @@
+import { FastifyInstance } from 'fastify';
+import {
+  getAttendanceSummariesHandler,
+  getAttendanceSummaryHandler,
+  createAttendanceSummaryHandler,
+  updateAttendanceSummaryHandler,
+  deleteAttendanceSummaryHandler,
+} from '../controllers/attendance_summaries.controller';
+
+export default async function attendanceSummariesRoutes(fastify: FastifyInstance) {
+  fastify.get<{
+    Querystring: { employee_id?: string; start_date?: string; end_date?: string };
+  }>('/attendance-summaries', { onRequest: [fastify.authenticate] }, getAttendanceSummariesHandler);
+  fastify.get<{ Params: { id: string } }>('/attendance-summaries/:id', { onRequest: [fastify.authenticate] }, getAttendanceSummaryHandler);
+  fastify.post('/attendance-summaries', { onRequest: [fastify.authenticate] }, createAttendanceSummaryHandler);
+  fastify.put<{ Params: { id: string } }>('/attendance-summaries/:id', { onRequest: [fastify.authenticate] }, updateAttendanceSummaryHandler);
+  fastify.delete<{ Params: { id: string } }>('/attendance-summaries/:id', { onRequest: [fastify.authenticate] }, deleteAttendanceSummaryHandler);
+}

--- a/src/backend/schemas/attendance_summaries.schema.ts
+++ b/src/backend/schemas/attendance_summaries.schema.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+
+export const createAttendanceSummarySchema = z.object({
+  employee_id: z.number().int(),
+  summary_date: z.string(),
+  working_minutes: z.number().int(),
+  overtime_minutes: z.number().int().optional().default(0),
+  break_minutes: z.number().int().optional().default(0),
+  is_late: z.boolean().optional().default(false),
+  is_left_early: z.boolean().optional().default(false),
+  notes: z.string().optional(),
+  is_active: z.boolean().optional().default(true),
+});
+
+export const updateAttendanceSummarySchema = z.object({
+  employee_id: z.number().int().optional(),
+  summary_date: z.string().optional(),
+  working_minutes: z.number().int().optional(),
+  overtime_minutes: z.number().int().optional(),
+  break_minutes: z.number().int().optional(),
+  is_late: z.boolean().optional(),
+  is_left_early: z.boolean().optional(),
+  notes: z.string().optional().nullable(),
+  is_active: z.boolean().optional(),
+});

--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -8,6 +8,7 @@ import userRolesRoutes from './routes/userRoles.routes';
 import roleRoutes from './routes/roles.routes';
 import departmentsRoutes from './routes/departments.routes';
 import attendanceRecordsRoutes from './routes/attendance_records.routes';
+import attendanceSummariesRoutes from './routes/attendance_summaries.routes';
 import dbPlugin from './plugins/db';
 import jwtPlugin from './utils/jwt';
 import employeeRoutes from './routes/employees.routes';
@@ -34,6 +35,7 @@ server.register(userRoutes);     // ユーザーマスタ
 server.register(workPatternRoutes);
 server.register(userRolesRoutes); // ユーザーロール
 server.register(attendanceRecordsRoutes);
+server.register(attendanceSummariesRoutes);
 
 const start = async () => {
   try {

--- a/src/backend/services/attendance_summaries.service.ts
+++ b/src/backend/services/attendance_summaries.service.ts
@@ -1,0 +1,160 @@
+import pool from '../utils/db';
+import { AttendanceSummary } from '../../shared/types';
+
+export const getAttendanceSummaries = async (filters: {
+  employee_id?: number;
+  start_date?: string;
+  end_date?: string;
+} = {}): Promise<AttendanceSummary[]> => {
+  const conditions: string[] = ['is_active = true'];
+  const values: any[] = [];
+  let idx = 1;
+
+  if (filters.employee_id !== undefined) {
+    conditions.push(`employee_id = $${idx++}`);
+    values.push(filters.employee_id);
+  }
+  if (filters.start_date !== undefined) {
+    conditions.push(`summary_date >= $${idx++}`);
+    values.push(filters.start_date);
+  }
+  if (filters.end_date !== undefined) {
+    conditions.push(`summary_date <= $${idx++}`);
+    values.push(filters.end_date);
+  }
+
+  const where = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
+  const result = await pool.query<AttendanceSummary>(
+    `SELECT * FROM t_attendance_summaries ${where} ORDER BY id`,
+    values
+  );
+  return result.rows;
+};
+
+export const getAttendanceSummary = async (
+  id: number
+): Promise<AttendanceSummary | null> => {
+  const result = await pool.query<AttendanceSummary>(
+    'SELECT * FROM t_attendance_summaries WHERE id = $1 AND is_active = true',
+    [id]
+  );
+  return result.rows[0] || null;
+};
+
+export const createAttendanceSummary = async (data: {
+  employee_id: number;
+  summary_date: string;
+  working_minutes: number;
+  overtime_minutes?: number;
+  break_minutes?: number;
+  is_late?: boolean;
+  is_left_early?: boolean;
+  notes?: string;
+  is_active?: boolean;
+}): Promise<AttendanceSummary> => {
+  const {
+    employee_id,
+    summary_date,
+    working_minutes,
+    overtime_minutes = 0,
+    break_minutes = 0,
+    is_late = false,
+    is_left_early = false,
+    notes = null,
+    is_active = true,
+  } = data;
+  const result = await pool.query<AttendanceSummary>(
+    'INSERT INTO t_attendance_summaries (employee_id, summary_date, working_minutes, overtime_minutes, break_minutes, is_late, is_left_early, notes, is_active, created_at, updated_at) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9, now(), now()) RETURNING *',
+    [
+      employee_id,
+      summary_date,
+      working_minutes,
+      overtime_minutes,
+      break_minutes,
+      is_late,
+      is_left_early,
+      notes,
+      is_active,
+    ]
+  );
+  return result.rows[0];
+};
+
+export const updateAttendanceSummary = async (
+  id: number,
+  data: {
+    employee_id?: number;
+    summary_date?: string;
+    working_minutes?: number;
+    overtime_minutes?: number;
+    break_minutes?: number;
+    is_late?: boolean;
+    is_left_early?: boolean;
+    notes?: string | null;
+    is_active?: boolean;
+  }
+): Promise<AttendanceSummary | null> => {
+  const fields: string[] = [];
+  const values: any[] = [];
+  let idx = 1;
+
+  if (data.employee_id !== undefined) {
+    fields.push(`employee_id = $${idx++}`);
+    values.push(data.employee_id);
+  }
+  if (data.summary_date !== undefined) {
+    fields.push(`summary_date = $${idx++}`);
+    values.push(data.summary_date);
+  }
+  if (data.working_minutes !== undefined) {
+    fields.push(`working_minutes = $${idx++}`);
+    values.push(data.working_minutes);
+  }
+  if (data.overtime_minutes !== undefined) {
+    fields.push(`overtime_minutes = $${idx++}`);
+    values.push(data.overtime_minutes);
+  }
+  if (data.break_minutes !== undefined) {
+    fields.push(`break_minutes = $${idx++}`);
+    values.push(data.break_minutes);
+  }
+  if (data.is_late !== undefined) {
+    fields.push(`is_late = $${idx++}`);
+    values.push(data.is_late);
+  }
+  if (data.is_left_early !== undefined) {
+    fields.push(`is_left_early = $${idx++}`);
+    values.push(data.is_left_early);
+  }
+  if (data.notes !== undefined) {
+    fields.push(`notes = $${idx++}`);
+    values.push(data.notes);
+  }
+  if (data.is_active !== undefined) {
+    fields.push(`is_active = $${idx++}`);
+    values.push(data.is_active);
+  }
+
+  if (fields.length === 0) {
+    return null;
+  }
+
+  fields.push('updated_at = now()');
+  values.push(id);
+
+  const result = await pool.query<AttendanceSummary>(
+    `UPDATE t_attendance_summaries SET ${fields.join(', ')} WHERE id = $${idx} RETURNING *`,
+    values
+  );
+  return result.rows[0] || null;
+};
+
+export const deleteAttendanceSummary = async (
+  id: number
+): Promise<AttendanceSummary | null> => {
+  const result = await pool.query<AttendanceSummary>(
+    'UPDATE t_attendance_summaries SET is_active = false, updated_at = now() WHERE id = $1 RETURNING *',
+    [id]
+  );
+  return result.rows[0] || null;
+};

--- a/src/shared/types/attendance_summaries.ts
+++ b/src/shared/types/attendance_summaries.ts
@@ -1,0 +1,14 @@
+export interface AttendanceSummary {
+  id: number;
+  employee_id: number;
+  summary_date: string;
+  working_minutes: number;
+  overtime_minutes: number;
+  break_minutes: number;
+  is_late: boolean;
+  is_left_early: boolean;
+  notes: string | null;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}

--- a/src/shared/types/index.d.ts
+++ b/src/shared/types/index.d.ts
@@ -91,3 +91,18 @@ export interface AttendanceRecord {
   created_at: string;
   updated_at: string;
 }
+
+export interface AttendanceSummary {
+  id: number;
+  employee_id: number;
+  summary_date: string;
+  working_minutes: number;
+  overtime_minutes: number;
+  break_minutes: number;
+  is_late: boolean;
+  is_left_early: boolean;
+  notes: string | null;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}


### PR DESCRIPTION
## Summary
- add AttendanceSummary interface
- implement service for attendance summary queries and mutations
- add controller and routes for attendance summaries
- define zod schema for attendance summary validation
- register new routes in server

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6879fe50d52c8331ac60405393d09463